### PR TITLE
Added <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObject…

### DIFF
--- a/OpenImageIO/OpenImageIOv13.vcxproj
+++ b/OpenImageIO/OpenImageIOv13.vcxproj
@@ -40,6 +40,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5BD48EC5-78D3-445E-B9CB-55A22E590EDE}</ProjectGuid>
     <RootNamespace>cycles_bvh</RootNamespace>
+	<VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="..\..\..\..\..\boostbuild\override.platform.props" Condition="exists('..\..\..\..\..\boostbuild\override.platform.props')" />

--- a/ccycles/ccycles.vcxproj
+++ b/ccycles/ccycles.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{060A4659-C327-4867-AAD8-E80C94DD1427}</ProjectGuid>
     <RootNamespace>c_api</RootNamespace>
+	<VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/clew/clew.vcxproj
+++ b/clew/clew.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B8C1A4CB-6207-49F7-BA7D-D8B5AF75F965}</ProjectGuid>
     <RootNamespace>clew</RootNamespace>
+	<VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="..\..\..\..\..\boostbuild\override.platform.props" Condition="exists('..\..\..\..\..\boostbuild\override.platform.props')" />

--- a/cuew/cuew.vcxproj
+++ b/cuew/cuew.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{92EB6D16-E6F5-47B7-928F-6BE64BA1B944}</ProjectGuid>
     <RootNamespace>cuew</RootNamespace>
+	<VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="..\..\..\..\..\boostbuild\override.platform.props" Condition="exists('..\..\..\..\..\boostbuild\override.platform.props')" />

--- a/cycles_proper.vcxproj
+++ b/cycles_proper.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{17AAA942-8C82-4160-8D23-78EA580377DD}</ProjectGuid>
     <RootNamespace>cycles_proper</RootNamespace>
+	<VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/glew/glew.vcxproj
+++ b/glew/glew.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1298F8E0-803D-4C1E-8D33-404138EAFE35}</ProjectGuid>
     <RootNamespace>glew</RootNamespace>
+	<VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="..\..\..\..\..\boostbuild\override.platform.props" Condition="exists('..\..\..\..\..\boostbuild\override.platform.props')" />

--- a/pthreads/pthreads.vcxproj
+++ b/pthreads/pthreads.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1F63EB7F-7A6E-49FA-AB49-52A5E66DCB8D}</ProjectGuid>
     <RootNamespace>pthreads</RootNamespace>
+	<VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="..\..\..\..\..\boostbuild\override.platform.props" Condition="exists('..\..\..\..\..\boostbuild\override.platform.props')" />


### PR DESCRIPTION
…Name> to V6 projects so they can be built with VS2019 without the need to upgrade the project.